### PR TITLE
Fix generated configuration example syntax in docs

### DIFF
--- a/website/docs/language/import/generating-configuration.mdx
+++ b/website/docs/language/import/generating-configuration.mdx
@@ -83,7 +83,7 @@ Terraform has generated configuration and written it to generated.tf. Please rev
 The example above instructs Terraform to generate configuration in a file named `generated.tf`. The below code is an example of a `generated.tf` file.
 
 ```hcl
-resource aws_iot_thing "bar" {
+resource "aws_iot_thing" "bar" {
   name = "foo"
 }
 ```


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

This PR fixes a broken syntax example in the `import/generating-configuration` documentation.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x/1.6.x

## Draft CHANGELOG entry

N/A. This change is a documentation fix only.